### PR TITLE
fix external build process for mars module

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -2,6 +2,10 @@
 # Makefile for MARS
 #
 
+ifneq ($(KBUILD_EXTMOD),)
+  CONFIG_MARS := m
+endif
+
 KBUILD_CFLAGS += -fdelete-null-pointer-checks
 
 mars-objs :=				\


### PR DESCRIPTION
Hi Thomas,

after you removed the mars big module build config settings you're removed some important switch which is needed for out-of-tree build. Here is the patch for that.
