### PR TITLE
deb: add fs.aio-max-nr into sysctl.d

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,8 @@ Homepage: http://schoebel.github.io/mars/
 
 Package: mars-dkms
 Architecture: any
-Depends: ${misc:Depends}, ${perl:Depends}
+Depends: ${misc:Depends}, ${perl:Depends}, procps
+Recommends: mars-tools
 Description: mars kernel module.
  MARS Light is a block-level storage replication solution implemented
  in the form of a Linux kernel module.

--- a/debian/mars-dkms.postinst
+++ b/debian/mars-dkms.postinst
@@ -8,6 +8,8 @@ case "$1" in
     ;;
 
     configure|reconfigure)
+        # Restart procps to reload sysctl.d files
+        invoke-rc.d procps restart
         # Get the version of the current loaded module:
         old_version="$(cat /sys/module/mars/version 2>/dev/null)" || exit 0
         # Get the version of the latest available module:

--- a/debian/mars-dkms.sysctl
+++ b/debian/mars-dkms.sysctl
@@ -1,0 +1,2 @@
+# System wide maximum number of asynchronous input/output requests
+fs.aio-max-nr = 1048560

--- a/debian/rules
+++ b/debian/rules
@@ -20,6 +20,7 @@ include /usr/share/dpkg/default.mk
 override_dh_install:
 	cp debian/mars-Makefile kernel/Makefile
 	cp debian/mars-Kbuild kernel/Kbuild
+	install -m 644 -D debian/mars-dkms.sysctl debian/mars-dkms/etc/sysctl.d/30-mars-dkms.conf
 	dh_install scripts/gen_config.pl usr/src/mars-$(DEB_VERSION_UPSTREAM)/
 	dh_install kernel/* usr/src/mars-$(DEB_VERSION_UPSTREAM)/
 


### PR DESCRIPTION
Hi @schoebel,

This patch enables a high number of asynchronous input/output requests as a `sysctl.d` configuration file. Default to `65535 * 16` which might be enough for busy systems.

When the package is installed the `fs.aio-max-nr` kernel variable will be set to a higher number, making the experience of using `mars-dkms` quite smooth.

Best,
Gabriel

