### PR TITLE
compat: fix parent dir locking

### DIFF
--- a/kernel/sy_old/sy_generic.c
+++ b/kernel/sy_old/sy_generic.c
@@ -458,7 +458,7 @@ retry:
 		goto exit1;
 #endif
 #ifdef HAS_INODE_LOCK_WRAPPERS
-	inode_lock_nested(dentry->d_inode, I_MUTEX_PARENT);
+	inode_lock_nested(parent->d_inode, I_MUTEX_PARENT);
 #else
 	mutex_lock_nested(&parent->d_inode->i_mutex, I_MUTEX_PARENT);
 #endif
@@ -493,7 +493,7 @@ exit3:
 	dput(dentry);
 exit2:
 #ifdef HAS_INODE_LOCK_WRAPPERS
-	inode_unlock(dentry->d_inode);
+	inode_unlock(parent->d_inode);
 #else
 	mutex_unlock(&parent->d_inode->i_mutex);
 #endif


### PR DESCRIPTION
Hi @schoebel,

this patch fixes a kernel null pointer dereference happening when loading the kernel module using a non-patched kernel:

``` 
[45429.850112] loading MARS, BUILDTAG=no-buildtag-available BUILDHOST=user@plug BUILDDATE=2020-11-20 03:45:11
[45429.888785] crc32c     digest duration =     40000961 ns
[45429.930720] crc32      digest duration =     40000962 ns
[45430.224742] sha1       digest duration =    296007121 ns
[45430.481893] md5old     digest duration =    256006162 ns
[45430.749409] md5        digest duration =    268006450 ns
[45430.784694] lzo      compress duration =     36000866 ns
[45430.827334] lz4      compress duration =     44001059 ns
[45431.798313] zlib     compress duration =    968023299 ns
[45431.907502] BUG: unable to handle kernel NULL pointer dereference at 00000000000000a8
[45431.907585] IP: [<ffffffffa801cc2b>] down_write+0x1b/0x40
[45431.907639] PGD 0 

[45431.907679] Oops: 0002 [#1] SMP
[45431.907707] Modules linked in: mars(O) tcp_diag udp_diag inet_diag loop fuse btrfs xor raid6_pq ufs qnx4 hfsplus hfs minix ntfs msdos jfs xfs libcrc32c snd_seq_dummy snd_hrtimer snd_seq snd_seq_device bnep lz4 lz4_compress zram zsmalloc nls_ascii nls_cp437 vfat fat pn544_mei mei_phy pn544 hci snd_hda_codec_hdmi nfc snd_hda_codec_realtek intel_rapl snd_hda_codec_generic x86_pkg_temp_thermal intel_powerclamp coretemp kvm_intel ppdev snd_hda_intel uvcvideo dell_wmi dell_laptop sparse_keymap videobuf2_vmalloc dell_smbios dcdbas videobuf2_memops kvm btusb videobuf2_v4l2 snd_hda_codec btrtl dell_smm_hwmon btbcm irqbypass videobuf2_core btintel snd_hda_core intel_cstate videodev intel_uncore snd_hwdep snd_pcm intel_rapl_perf bluetooth joydev media efi_pstore iwlwifi snd_timer iTCO_wdt serio_raw sg efivars
[45431.908520]  snd pcspkr mei_me iTCO_vendor_support cfg80211 soundcore mei shpchp battery parport_pc parport dell_smo8800 dell_rbtn evdev rfkill ac msr efivarfs ip_tables x_tables autofs4 ext4 crc16 jbd2 crc32c_generic fscrypto ecb mbcache dm_crypt dm_mod sd_mod crct10dif_pclmul crc32_pclmul crc32c_intel ghash_clmulni_intel aesni_intel aes_x86_64 lrw gf128mul glue_helper ablk_helper cryptd ahci libahci psmouse lpc_ich mfd_core i915 i2c_algo_bit ehci_pci xhci_pci ehci_hcd xhci_hcd sdhci_pci libata sdhci drm_kms_helper scsi_mod i2c_i801 i2c_smbus mmc_core drm e1000e ptp usbcore pps_core usb_common thermal wmi video button [last unloaded: mars]
[45431.909198] CPU: 2 PID: 120920 Comm: mars_main Tainted: G           O    4.9.0-13-amd64 #1 Debian 4.9.228-1
[45431.909270] Hardware name: Dell Inc. Latitude E7440/03M26R, BIOS A08 02/18/2014
[45431.909326] task: ffff9e8b3c7f7040 task.stack: ffffbe4c83754000
[45431.909373] RIP: 0010:[<ffffffffa801cc2b>]  [<ffffffffa801cc2b>] down_write+0x1b/0x40
[45431.909439] RSP: 0018:ffffbe4c83757c10  EFLAGS: 00010246
[45431.909481] RAX: 00000000000000a8 RBX: 00000000000000a8 RCX: 0000000000000000
[45431.909536] RDX: ffffffff00000001 RSI: 0000000000000001 RDI: 00000000000000a8
[45431.909590] RBP: ffff9e8bd0e51340 R08: ffffbe4c83757a24 R09: 000000000000000b
[45431.909645] R10: 000000009866b9f3 R11: ffff9e8b1c8b0ab8 R12: ffff9e8bd3d9bf40
[45431.909699] R13: 0000000000000000 R14: ffff9e8bd0e51352 R15: 0000000000000000
[45431.909755] FS:  0000000000000000(0000) GS:ffff9e8bdeb00000(0000) knlGS:0000000000000000
[45431.909816] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[45431.909861] CR2: 00000000000000a8 CR3: 000000007c208000 CR4: 0000000000160670
[45431.909915] Stack:
[45431.909935]  ffff9e8b1c8b0a80 ffffffffc0e0e613 ffff9e8bd113e3e0 ffff9e8b1c8b0a80
[45431.910005]  927c98dda1531375 ffff9e8b3c7f7040 ffffffffffffffff ffff9e8bd3d9bf40
[45431.910075]  ffff9e8b6fdb59e0 a3d70a3d70a3d70b 0000000000000000 ffffffffc0e0f1f7
[45431.910143] Call Trace:
[45431.910205]  [<ffffffffc0e0e613>] ? _compat_unlink+0xe3/0x1c0 [mars]
[45431.910276]  [<ffffffffc0e0f1f7>] ? mars_unlink+0x27/0x40 [mars]
[45431.910342]  [<ffffffffc0e0f514>] ? compat_ordered_symlink+0x104/0x140 [mars]
[45431.910413]  [<ffffffffc0ded390>] ? _brick_string_alloc+0x20/0x40 [mars]
[45431.910485]  [<ffffffffc0e0cf34>] ? mars_readlink+0x104/0x330 [mars]
[45431.910554]  [<ffffffffc0e0f830>] ? ordered_symlink+0x30/0x130 [mars]
[45431.910626]  [<ffffffffc0e1863f>] ? __make_alivelink_str+0x14f/0x190 [mars]
[45431.910701]  [<ffffffffc0e186b3>] ? __make_alivelink+0x33/0x50 [mars]
[45431.910772]  [<ffffffffc0e23fda>] ? _main_thread+0x57a/0xab0 [mars]
[45431.910825]  [<ffffffffa801f3b1>] ? __switch_to_asm+0x41/0x70
[45431.910872]  [<ffffffffa801f3a5>] ? __switch_to_asm+0x35/0x70
[45431.910919]  [<ffffffffa801a4e1>] ? __schedule+0x241/0x6f0
[45431.910965]  [<ffffffffa7abea2f>] ? __wake_up_common+0x4f/0x90
[45431.911031]  [<ffffffffc0e23a60>] ? check_deleted+0x120/0x120 [mars]
[45431.911084]  [<ffffffffa7a9be69>] ? kthread+0xd9/0xf0
[45431.911128]  [<ffffffffa801f3b1>] ? __switch_to_asm+0x41/0x70
[45431.911176]  [<ffffffffa7a9bd90>] ? kthread_park+0x60/0x60
[45431.911221]  [<ffffffffa801f437>] ? ret_from_fork+0x57/0x70
[45431.911265] Code: 01 74 08 48 c7 43 20 01 00 00 00 5b c3 0f 1f 00 0f 1f 44 00 00 53 48 89 fb e8 a2 df ff ff 48 ba 01 00 00 00 ff ff ff ff 48 89 d8 <f0> 48 0f c1 10 85 d2 74 05 e8 97 95 d2 ff 65 48 8b 04 25 c0 fb 
[45431.911632] RIP  [<ffffffffa801cc2b>] down_write+0x1b/0x40
[45431.911681]  RSP <ffffbe4c83757c10>
[45431.911709] CR2: 00000000000000a8
[45431.930186] ---[ end trace 44889cca472efd05 ]---

```

Best,
Gabriel Francisco