### PR TITLE
fix spelling in comments

### DIFF
--- a/kernel/lamport.c
+++ b/kernel/lamport.c
@@ -149,7 +149,7 @@ void _set_lamport_nonstrict(struct lamport_clock *clock,
 {
 	protect_lamport_time(lamport_advance);
 
-	/*  Speculate that advaning is not necessary, to avoid the lock
+	/*  Speculate that advancing is not necessary, to avoid the lock
 	 */
 	if (lamport_time_compare(lamport_advance, &clock->lamport_stamp) > 0) {
 		down_write(&clock->lamport_sem);
@@ -191,7 +191,7 @@ void _set_get_lamport(struct lamport_clock *clock,
 }
 EXPORT_SYMBOL_GPL(_set_get_lamport);
 
-/* Protect against illegal values, e.g. from currupt filesystems etc.
+/* Protect against illegal values, e.g. from corrupt filesystems etc.
  */
 
 int max_lamport_future = 30 * 24 * 3600;

--- a/kernel/lamport.h
+++ b/kernel/lamport.h
@@ -74,7 +74,7 @@ struct lamport_clock {
 
 extern struct lamport_clock global_lamport;
 
-/* Protect against illegal values, e.g. from currupt filesystems etc.
+/* Protect against illegal values, e.g. from corrupt filesystems etc.
  */
 extern int max_lamport_future;
 

--- a/kernel/lib_limiter.c
+++ b/kernel/lib_limiter.c
@@ -66,7 +66,7 @@ int mars_limit(struct mars_limiter *lim, int amount)
 		int rate;
 		int max_rate;
 
-		/* Sometimes, raw CPU clocks may do weired things...
+		/* Sometimes, raw CPU clocks may do weird things...
 		 * Small windows in the denominator could fake unrealistic rates.
 		 * Do not divide by too small numbers.
 		 */

--- a/kernel/mars_aio.c
+++ b/kernel/mars_aio.c
@@ -516,7 +516,7 @@ void aio_stop_thread(struct aio_output *output, int i, bool do_submit_dummy)
 		MARS_DBG("stopping thread %d ...\n", i);
 		tinfo->should_terminate = true;
 
-		// workaround for waking up the receiver thread. TODO: check whether signal handlong could do better.
+		// workaround for waking up the receiver thread. TODO: check whether signal handling could do better.
 		if (do_submit_dummy) {
 			MARS_DBG("submitting dummy for wakeup %d...\n", i);
 			use_fake_mm();
@@ -852,7 +852,7 @@ void _destroy_ioctx(struct aio_output *output)
 
 /* TODO: this is provisionary. We only need it for sys_io_submit()
  * which uses userspace concepts like file handles.
- * This should be replaced by a future kernelsapce vfs_submit() or
+ * This should be replaced by a future kernelspace vfs_submit() or
  * do_submit() which currently does not exist :(
  * Or, the whole aio brick should be replaced by something else.
  * A good candidate could be the new {read,write}_iter() infrastructure.

--- a/kernel/mars_check.c
+++ b/kernel/mars_check.c
@@ -26,7 +26,7 @@
  * checks various semantic properties, uses watchdog to find lost callbacks.
  */
 
-/* FIXME: this code has been unused for a long time, it is unlikly
+/* FIXME: this code has been unused for a long time, it is unlikely
  * to work at all.
  */
 

--- a/kernel/mars_copy.c
+++ b/kernel/mars_copy.c
@@ -472,7 +472,7 @@ restart:
 		next_state = COPY_STATE_START;
 		/* fallthrough */
 	case COPY_STATE_START:
-		/* This is the relgular starting state.
+		/* This is the regular starting state.
 		 * It must be zero, automatically entered via memset()
 		 */
 		if ((unsigned long)READ_ONCE(st->table[0]) |

--- a/kernel/mars_generic.c
+++ b/kernel/mars_generic.c
@@ -59,7 +59,7 @@ char *my_id(void)
 	if (unlikely(!id[0])) {
 		struct new_utsname *u;
 
-		//down_read(&uts_sem); // FIXME: this is currenty not EXPORTed from the kernel!
+		//down_read(&uts_sem); // FIXME: this is currently not EXPORTed from the kernel!
 		u = utsname();
 		if (u) {
 			strncpy(id, u->nodename, sizeof(id));

--- a/kernel/mars_if.c
+++ b/kernel/mars_if.c
@@ -420,7 +420,7 @@ void if_make_request(struct request_queue *q, struct bio *bio)
 	const int  sectors = bio_sectors(bio);
 //      remove_this
 /* Adapt to different kernel versions.
- * This is a maintainance nightmare.
+ * This is a maintenance nightmare.
  * Most is provisionary.
  */
 #if defined(BIO_RW_RQ_MASK) || defined(BIO_FLUSH)


### PR DESCRIPTION
I skimmed through the mars source code just to get an idea about the project state. While I can hardly claim to understand what the code does I noticed a few trivial spelling errors and I could not let these slip past... Feel free to ignore this PR though - it's really not important.